### PR TITLE
Handle <not supported> and <not counted> values of metrics

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/intelsdi-x/snap-plugin-collector-perfevents",
-	"GoVersion": "go1.6",
-	"GodepVersion": "v62",
+	"GoVersion": "go1.5",
+	"GodepVersion": "v69",
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
@@ -9,63 +9,77 @@
 			"Rev": "55eb11d21d2a31a3cc93838241d04800f52e823d"
 		},
 		{
+			"ImportPath": "github.com/golang/protobuf/proto",
+			"Rev": "8616e8ee5e20a1704615e6c8d7afcdac06087a67"
+		},
+		{
 			"ImportPath": "github.com/gopherjs/gopherjs/js",
 			"Rev": "4b53e1bddba0e2f734514aeb6c02db652f4c6fe8"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/cpolicy",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encoding",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encrypter",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/rpc",
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/cdata",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/ctypes",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/serror",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/grpc/common",
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/ctree",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/schedule",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/scheduler/wmap",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-220-gbd91fba",
+			"Rev": "bd91fbac4d93acf7a66545fc79c359a5be22b6a6"
 		},
 		{
 			"ImportPath": "github.com/jtolds/gls",
@@ -106,6 +120,66 @@
 			"ImportPath": "github.com/smartystreets/goconvey/convey/reporting",
 			"Comment": "1.6.0-10-g995f5b2",
 			"Rev": "995f5b2e021c69b8b028ba6d0b05c1dd500783db"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/http2",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/http2/hpack",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/internal/timeseries",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/lex/httplex",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "golang.org/x/net/trace",
+			"Rev": "154d9f9ea81208afed560f4cf27b4860c8ed1904"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/codes",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/credentials",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/grpclog",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/internal",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/metadata",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/naming",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/peer",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/transport",
+			"Rev": "88aeffff979aa77aa502cb011423d0a08fa12c5a"
 		},
 		{
 			"ImportPath": "gopkg.in/yaml.v2",

--- a/examples/tasks/perfevents-file.json
+++ b/examples/tasks/perfevents-file.json
@@ -1,0 +1,22 @@
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "3s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/linux/perfevents/*" :{}
+            },
+	   "publish": [
+                        {
+                            "plugin_name": "file",
+                            "config": {
+                                "file": "/tmp/published_perfevents"
+                            }
+                        }
+                ]
+        }
+    }
+}


### PR DESCRIPTION
Fixed #26 

Summary of changes:
- added handler of not counted values   
(e.g. output of perf cmd: `<not counted>;;branch-misses;user.slice;0;100,00`)  
- added handler of not supported events   
(e.g. output of perf cmd `<not supported>;;stalled-cycles-backend;user.slice;0;100,00`)
- added exemplary task manifest
- updated Godeps to the latest snap master
- updated README.md

Testing done:
- run exemplary task manifest on platform where some of perf counters are not supported
- run existing unit test

@intelsdi-x/plugin-maintainers 